### PR TITLE
Get basic Behat POC running

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -1,11 +1,14 @@
 default:
-    suites:
-        default:
-            contexts:
-                - Zenstruck\Foundry\Tests\Behat\TestContext
-                - Zenstruck\Foundry\Test\Behat\FactoriesContext
     extensions:
         FriendsOfBehat\SymfonyExtension:
             kernel:
                 class: Zenstruck\Foundry\Tests\Fixtures\Kernel
             bootstrap: tests/bootstrap.php
+
+    suites:
+        default:
+            paths: [ "%paths.base%/tests/Behat" ]
+            contexts:
+                - Zenstruck\Foundry\Tests\Behat\TestContext
+                - Zenstruck\Foundry\Test\Behat\FactoriesContext
+                - Zenstruck\Foundry\Test\Behat\ResetDatabaseContext

--- a/src/Bundle/DependencyInjection/ZenstruckFoundryExtension.php
+++ b/src/Bundle/DependencyInjection/ZenstruckFoundryExtension.php
@@ -16,6 +16,7 @@ use Zenstruck\Foundry\Bundle\Command\StubMakeStory;
 use Zenstruck\Foundry\ModelFactory;
 use Zenstruck\Foundry\Story;
 use Zenstruck\Foundry\Test\Behat\FactoriesContext;
+use Zenstruck\Foundry\Test\Behat\ResetDatabaseContext;
 use Zenstruck\Foundry\Test\ORMDatabaseResetter;
 
 /**
@@ -54,10 +55,8 @@ final class ZenstruckFoundryExtension extends ConfigurableExtension
         }
 
         if (self::isBundleLoaded($container, FriendsOfBehatSymfonyExtensionBundle::class)) {
-            $container->register('.zenstruck_foundry.behat.factories_context', FactoriesContext::class)
-                ->addArgument(new Reference('service_container'))
-                ->addTag('fob.context')
-            ;
+            $container->register(FactoriesContext::class)->addArgument(new Reference('service_container'))->setAutoconfigured(true);
+            $container->register(ResetDatabaseContext::class)->setAutowired(true)->setAutoconfigured(true);
         }
     }
 

--- a/src/Test/Behat/ResetDatabaseContext.php
+++ b/src/Test/Behat/ResetDatabaseContext.php
@@ -24,7 +24,7 @@ final class ResetDatabaseContext implements Context
     }
 
     /**
-     * @BeforeScenario
+     * @AfterScenario
      */
     public function resetSchema(): void
     {

--- a/src/Test/Behat/ResetDatabaseContext.php
+++ b/src/Test/Behat/ResetDatabaseContext.php
@@ -3,7 +3,7 @@
 namespace Zenstruck\Foundry\Test\Behat;
 
 use Behat\Behat\Context\Context;
-use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Zenstruck\Foundry\Test\DatabaseResetter;
 
 /**
@@ -11,16 +11,16 @@ use Zenstruck\Foundry\Test\DatabaseResetter;
  */
 final class ResetDatabaseContext implements Context
 {
-    public function __construct(private ContainerInterface $container)
+    public function __construct(private KernelInterface $kernel)
     {
     }
 
     /**
-     * @BeforeSuite
+     * @BeforeScenario
      */
     public function resetDatabase(): void
     {
-        DatabaseResetter::resetDatabase($this->container->get('kernel'));
+        DatabaseResetter::resetDatabase($this->kernel);
     }
 
     /**
@@ -28,6 +28,6 @@ final class ResetDatabaseContext implements Context
      */
     public function resetSchema(): void
     {
-        DatabaseResetter::resetSchema($this->container->get('kernel'));
+        DatabaseResetter::resetSchema($this->kernel);
     }
 }

--- a/tests/Behat/Foundry.feature
+++ b/tests/Behat/Foundry.feature
@@ -1,0 +1,15 @@
+Feature: Behat support for Foundry
+
+    As a developer writing tests with Behat, I want to be able to
+    use Foundry for creating test data. Foundry needs to be configured,
+    started and stopped accordingly. The database has to be reset before
+    scenarios are run.
+
+    Scenario: Creating two categories
+        When I create 2 categories
+        Then there should be 2 categories in the database
+
+    Scenario: Adding to the database
+        Given 1 category has been created
+        When I create 2 categories
+        Then there should be 3 categories in the database

--- a/tests/Behat/TestContext.php
+++ b/tests/Behat/TestContext.php
@@ -11,17 +11,18 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
 final class TestContext implements Context
 {
     /**
-     * @Given there is :count category
+     * @Given /^(?P<count>\d+) (?:category has|categories have) been created$/
+     * @When /^I create (?P<count>\d+) categor(?:y|ies)$/
      */
-    public function thereIsCategory(int $count): void
+    public function createCategories(int $count): void
     {
         CategoryFactory::createMany($count);
     }
 
     /**
-     * @Then there is :count category in the database
+     * @Then /^there should be (?P<count>\d+) categor(?:y|ies) in the database$/
      */
-    public function thereIsCategoryInTheDatabase(int $count): void
+    public function assertCategoryCount(int $count): void
     {
         CategoryFactory::assert()->count($count);
     }

--- a/tests/Fixtures/Kernel.php
+++ b/tests/Fixtures/Kernel.php
@@ -12,9 +12,12 @@ use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Bundle\MakerBundle\MakerBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
+use Zenstruck\Foundry\Test\Behat\FactoriesContext;
 use Zenstruck\Foundry\Test\ORMDatabaseResetter;
+use Zenstruck\Foundry\Tests\Behat\TestContext;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\AddressFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryServiceFactory;
@@ -100,6 +103,10 @@ class Kernel extends BaseKernel
             ->setAutoconfigured(true)
             ->setAutowired(true)
         ;
+
+        $c->register(TestContext::class)
+            ->setAutoconfigured(true)
+            ->setAutowired(true);
 
         foreach ($this->factoriesRegistered as $factory) {
             $c->register($factory)


### PR DESCRIPTION
Given the database has been created, at least the following now works for me™️:

```
$ USE_ORM=1 USE_FOUNDRY_BUNDLE=1 DATABASE_URL=mysqli://root@localhost/zenstruck_foundry__test php8.1 vendor/bin/behat
Feature: Behat support for Foundry

    As a developer writing tests with Behat, I want to be able to
    use Foundry for creating test data. Foundry needs to be configured,
    started and stopped accordingly. The database has to be reset before
    scenarios are run.

  Scenario: Creating two categories                   # tests/Behat/Foundry.feature:8
    When I create 2 categories                        # Zenstruck\Foundry\Tests\Behat\TestContext::createCategories()
    Then there should be 2 categories in the database # Zenstruck\Foundry\Tests\Behat\TestContext::assertCategoryCount()

  Scenario: Adding to the database                    # tests/Behat/Foundry.feature:12
    Given 1 category has been created                 # Zenstruck\Foundry\Tests\Behat\TestContext::createCategories()
    When I create 2 categories                        # Zenstruck\Foundry\Tests\Behat\TestContext::createCategories()
    Then there should be 3 categories in the database # Zenstruck\Foundry\Tests\Behat\TestContext::assertCategoryCount()

2 scenarios (2 passed)
5 steps (5 passed)
0m11.39s (35.34Mb)
``` 